### PR TITLE
PowerShell revisions

### DIFF
--- a/main.go
+++ b/main.go
@@ -246,7 +246,10 @@ func shell(args ...string) error {
 	var shellCmdLine string
 	if app.Conf.Shell == "powershell" {
 		shellProc, _ = exec.LookPath("powershell.exe")
-		shellCmdLine = fmt.Sprintf("-? -NoExit -Command %s", fs.RemoveUnc(launchScript))
+		shellCmdLine = fmt.Sprintf(" -NoExit -ExecutionPolicy Unrestricted -Command %s", fs.RemoveUnc(launchScript))
+	} else if app.Conf.Shell == "pwsh" {
+		shellProc, _ = exec.LookPath("pwsh.exe")
+		shellCmdLine = fmt.Sprintf(" -NoExit -ExecutionPolicy Unrestricted -Command %s", fs.RemoveUnc(launchScript))
 	} else {
 		shellProc = os.Getenv("COMSPEC")
 		shellCmdLine = fmt.Sprintf(` /k "%s"`, fs.RemoveUnc(launchScript))


### PR DESCRIPTION
`-?` (tied to the help output) was previously there, presumably to prevent a crash, but all that line really needed was to start with a space just like the cmd option.

`-ExecutionPolicy Unrestricted` was added so that script calls in `Microsoft.PowerShell_profile.ps1` don't cause errors when opening. (Not sure why it happens when my system is already set to that, I'm guessing it's probably related to the way the app sandboxes things.)

`pwsh` was added as an option, which is tied to versions of PowerShell beyond 5.1.